### PR TITLE
Fix terminal Escape focus handling

### DIFF
--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -26,6 +26,7 @@ const COPY_TOAST_ID = 'terminal-copy';
 const DEFAULT_FONT_SIZE = 12;
 const ESC = '\x1b';
 const POINTER_BLUR_GRACE_MS = 200;
+const SYNTHETIC_ESC_NUL_GRACE_MS = 100;
 
 const ALLOWED_LINK_PROTOCOLS = ['http:', 'https:'];
 
@@ -217,7 +218,14 @@ const useTerminal = ({ theme, fontSize = DEFAULT_FONT_SIZE, onInput, onResize, o
       terminalInstance.current = terminal;
       fitAddonRef.current = fitAddon;
 
+      let lastSyntheticEscAt = 0;
+      const sendSyntheticEsc = () => {
+        lastSyntheticEscAt = performance.now();
+        callbacksRef.current.onInput?.(ESC);
+      };
+
       terminal.onData((data) => {
+        if (data === '\x00' && performance.now() - lastSyntheticEscAt < SYNTHETIC_ESC_NUL_GRACE_MS) return;
         if (/^\x1b\[[\?>]?[\d;]*[cnR]$/.test(data)) return;
         callbacksRef.current.onInput?.(data);
       });
@@ -235,7 +243,7 @@ const useTerminal = ({ theme, fontSize = DEFAULT_FONT_SIZE, onInput, onResize, o
           !event.metaKey
         ) {
           // 일부 브라우저/PWA 포커스 경로에서는 xterm이 데이터를 emit하기 전에 첫 Escape가 유실될 수 있다.
-          callbacksRef.current.onInput?.(ESC);
+          sendSyntheticEsc();
           event.preventDefault();
           event.stopPropagation();
           return false;
@@ -297,7 +305,7 @@ const useTerminal = ({ theme, fontSize = DEFAULT_FONT_SIZE, onInput, onResize, o
           if (document.activeElement !== document.body) return;
           if (performance.now() - lastPointerDownAt < POINTER_BLUR_GRACE_MS) return;
 
-          callbacksRef.current.onInput?.(ESC);
+          sendSyntheticEsc();
           terminal.focus();
         });
       };

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -234,6 +234,7 @@ const useTerminal = ({ theme, fontSize = DEFAULT_FONT_SIZE, onInput, onResize, o
           !event.ctrlKey &&
           !event.metaKey
         ) {
+          // 일부 브라우저/PWA 포커스 경로에서는 xterm이 데이터를 emit하기 전에 첫 Escape가 유실될 수 있다.
           callbacksRef.current.onInput?.(ESC);
           event.preventDefault();
           event.stopPropagation();
@@ -279,6 +280,8 @@ const useTerminal = ({ theme, fontSize = DEFAULT_FONT_SIZE, onInput, onResize, o
 
       resizeObserver.observe(containerNode);
 
+      // Escape가 xterm helper textarea를 먼저 blur시키면 해당 blur를 Escape로 보정한다.
+      // 직전 pointer 입력은 터미널 밖 클릭/터치로 인한 blur일 가능성이 높으므로 입력을 합성하지 않는다.
       let lastPointerDownAt = 0;
       const onPointerDown = () => {
         lastPointerDownAt = performance.now();

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -24,6 +24,8 @@ interface IUseTerminalOptions {
 const COPY_TOAST_ID = 'terminal-copy';
 
 const DEFAULT_FONT_SIZE = 12;
+const ESC = '\x1b';
+const POINTER_BLUR_GRACE_MS = 200;
 
 const ALLOWED_LINK_PROTOCOLS = ['http:', 'https:'];
 
@@ -162,6 +164,7 @@ const useTerminal = ({ theme, fontSize = DEFAULT_FONT_SIZE, onInput, onResize, o
     let reFitTimer = 0;
     let resizeObserver: ResizeObserver | null = null;
     let cleanupTouch: (() => void) | null = null;
+    let cleanupFocusGuard: (() => void) | null = null;
 
     loadFonts().then(() => {
       if (disposed) return;
@@ -224,12 +227,25 @@ const useTerminal = ({ theme, fontSize = DEFAULT_FONT_SIZE, onInput, onResize, o
       });
 
       terminal.attachCustomKeyEventHandler((event) => {
+        if (
+          event.type === 'keydown' &&
+          event.key === 'Escape' &&
+          !event.altKey &&
+          !event.ctrlKey &&
+          !event.metaKey
+        ) {
+          callbacksRef.current.onInput?.(ESC);
+          event.preventDefault();
+          event.stopPropagation();
+          return false;
+        }
+
         // macOptionIsMeta가 이중 ESC를 보내는 키만 직접 매핑
         if (event.altKey && event.type === 'keydown') {
           const seq: Record<string, string> = {
-            ArrowLeft: '\x1bb',
-            ArrowRight: '\x1bf',
-            Backspace: '\x1b\x7f',
+            ArrowLeft: `${ESC}b`,
+            ArrowRight: `${ESC}f`,
+            Backspace: `${ESC}\x7f`,
           };
           if (seq[event.code]) {
             callbacksRef.current.onInput?.(seq[event.code]);
@@ -262,6 +278,33 @@ const useTerminal = ({ theme, fontSize = DEFAULT_FONT_SIZE, onInput, onResize, o
       });
 
       resizeObserver.observe(containerNode);
+
+      let lastPointerDownAt = 0;
+      const onPointerDown = () => {
+        lastPointerDownAt = performance.now();
+      };
+      const onFocusOut = (event: FocusEvent) => {
+        const target = event.target;
+        if (!(target instanceof HTMLTextAreaElement)) return;
+        if (!target.classList.contains('xterm-helper-textarea')) return;
+
+        requestAnimationFrame(() => {
+          if (disposed) return;
+          if (document.visibilityState !== 'visible') return;
+          if (document.activeElement !== document.body) return;
+          if (performance.now() - lastPointerDownAt < POINTER_BLUR_GRACE_MS) return;
+
+          callbacksRef.current.onInput?.(ESC);
+          terminal.focus();
+        });
+      };
+
+      document.addEventListener('pointerdown', onPointerDown, true);
+      containerNode.addEventListener('focusout', onFocusOut, true);
+      cleanupFocusGuard = () => {
+        document.removeEventListener('pointerdown', onPointerDown, true);
+        containerNode.removeEventListener('focusout', onFocusOut, true);
+      };
 
       // 모바일 터치 → 합성 WheelEvent 변환 (tmux 스크롤 지원)
       // tmux mouse mode 시 xterm.js가 .xterm-screen에 wheel 리스너를 붙이므로 해당 요소에 dispatch
@@ -309,6 +352,7 @@ const useTerminal = ({ theme, fontSize = DEFAULT_FONT_SIZE, onInput, onResize, o
       clearTimeout(reFitTimer);
       resizeObserver?.disconnect();
       cleanupTouch?.();
+      cleanupFocusGuard?.();
       terminalInstance.current?.dispose();
       terminalInstance.current = null;
       fitAddonRef.current = null;


### PR DESCRIPTION
## 배경

purplemux 터미널에서 일반 키 입력과 방향키는 정상 동작하지만, `Esc`만 첫 입력에서 Claude/Codex TUI까지 안정적으로 전달되지 않는 문제가 있었습니다.

조사 과정에서 다음을 확인했습니다.

- 로컬 터미널에서는 `command cat -v` 실행 후 `Esc` 입력 시 `^[`가 정상 출력됩니다.
- purplemux 터미널에서는 첫 `Esc` 입력 시 `keydown`/`keyup` 이벤트가 DOM에 찍히지 않고, `.xterm-helper-textarea`가 blur/focusout 되며 `document.activeElement`가 `BODY`로 떨어지는 경우가 있습니다.
- 이후 두 번째 `Esc`부터는 `keydown Escape`가 DOM에 들어오는 경우가 있습니다.
- 보정 후 일부 상황에서 `command cat -v`에 `^[^@`처럼 `ESC + NUL`이 관찰되었고, Claude/Codex의 `/plugin` 화면에서는 이 후속 NUL 때문에 Esc 단독 입력으로 해석되지 않을 가능성이 있었습니다.
- 따라서 tmux나 Claude/Codex 자체 문제라기보다, 웹 터미널의 xterm helper textarea 포커스 처리와 브라우저/입력 계층 사이에서 첫 `Esc`가 소비되거나 후속 입력이 섞이는 현상으로 판단했습니다.

## 수정한 내용

- xterm `attachCustomKeyEventHandler`에서 modifier 없는 `Escape` `keydown`이 들어오면 직접 `\x1b`를 `onInput`으로 전달하도록 했습니다.
- 첫 `Esc`처럼 key 이벤트가 들어오지 않고 `.xterm-helper-textarea`가 `BODY`로 blur 되는 경우를 fallback으로 처리했습니다.
  - 직전 pointerdown이 없는 focusout인지 확인합니다.
  - 문서가 visible이고 active element가 `BODY`로 떨어진 경우에만 `\x1b`를 전달합니다.
  - 이후 `terminal.focus()`로 터미널 포커스를 복원합니다.
- synthetic Esc를 보낼 때 시각을 기록하고, 직후 짧은 시간 안에 xterm `onData`로 들어오는 단독 `NUL(\x00)`은 무시하도록 했습니다.
  - `command cat -v`에서 관찰된 `^[^@` 케이스를 `^[`로 정리하기 위한 제한적인 보정입니다.
  - 일반 입력의 NUL을 전역으로 막지 않고, synthetic Esc 직후 100ms 안의 단독 NUL만 대상으로 제한했습니다.
- 기존 Option+Arrow/Backspace 매핑에서 ESC 리터럴을 상수로 재사용하도록 정리했습니다.
- 보정 로직의 의도를 한국어 주석으로 추가했습니다.

## 결과

- `command cat -v`에서 synthetic Esc 뒤에 붙던 `^@`가 제거되어 `^[`만 남는 것을 확인했습니다.
- Claude/Codex의 `/plugin` 화면에서 Esc로 go back이 동작하는 것을 확인했습니다.
- `pnpm lint` 통과
- `pnpm build` 통과

## 아직 해결하지 못한 내용 / 한계

- 첫 `Esc`가 DOM key event로 들어오지 않는 원인 자체를 제거한 것은 아닙니다. 현재 수정은 xterm helper textarea의 `focusout`과 synthetic Esc 후속 입력을 기반으로 한 fallback입니다.
- `focusout`만으로 사용자의 의도를 100% 구분할 수 없기 때문에, 직전 pointerdown 여부와 active element 상태를 조건으로 제한했습니다.
- NUL 억제는 전체 NUL 입력을 막지 않고 synthetic Esc 직후 단독 NUL에만 적용했습니다. 다른 경로에서 실제 NUL 입력이 필요한 경우에는 영향을 주지 않도록 범위를 좁혔습니다.

## 참고한 레퍼런스

- xterm.js `Terminal` API 문서: `attachCustomKeyEventHandler`, `focus`, `onData` 흐름을 확인했습니다.  
  https://xtermjs.org/docs/api/terminal/classes/terminal/

- xterm.js 이슈: xterm 입력 처리 중 플랫폼/브라우저/embedding 환경에 따라 embedder 쪽 보정이 필요한 사례를 확인했습니다.  
  https://github.com/xtermjs/xterm.js/issues/4538

- xterm.js 이슈: IME/브라우저 레벨 입력 문제가 xterm 단독으로 해결되지 않는 사례를 확인했습니다.  
  https://github.com/xtermjs/xterm.js/issues/2151

- 브라우저 입력 필드에서 `Escape` key event가 기대대로 발생하지 않는 유사 사례를 확인했습니다.  
  https://stackoverflow.com/questions/12927752/keydown-keyup-events-not-detecting-the-escape-key-being-pressed-on-input-text-fi

- 브라우저/확장/포커스 상태에 따라 focused element에서 Escape 이벤트가 잡히지 않는 사례를 확인했습니다.  
  https://stackoverflow.com/questions/35352918/key-events-are-not-raised-when-escape-key-is-pressed-on-a-focused-element
